### PR TITLE
fix: Could not import extension sphinx.ext.pngmath

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ sys.path.insert(0, os.path.abspath('..'))
 
 extensions = [
     'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx',
-    'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.pngmath',
+    'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig'
 ]
 


### PR DESCRIPTION
In the new version of Sphinx, sphinx.ext.pngmath is renamed sphinx.ext.imgmath